### PR TITLE
Added default file extensions if missing

### DIFF
--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -35,9 +35,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.sakaiproject.assignment.api.AssignmentConstants;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.authz.api.SecurityService;
@@ -114,9 +114,7 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 	private static final String HEADER_CONTENT = "Content-Type";
 	private static final String HEADER_DISP = "Content-Disposition";
 	
-	private static final String INLINE_SUBMISSION = "Inline Submission";
 	private static final String HTML_EXTENSION = ".html";
-	private static final String DOCX_EXTENSION = ".docx";
 
 	private static final String STATUS_CREATED = "CREATED";
 	private static final String STATUS_COMPLETE = "COMPLETE";
@@ -667,23 +665,18 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 			// EXTERNAL ID DOES NOT EXIST, CREATE SUBMISSION AND UPLOAD CONTENTS TO TCA
 			// (STAGE 1)
 			if (StringUtils.isEmpty(item.getExternalId())) {
-				// Get filename of submission
-				String fileName = resource.getProperties().getProperty(ResourceProperties.PROP_DISPLAY_NAME);
-				// If file name is missing extension add to fulfill TCA header requirement
-				if (FilenameUtils.getExtension(fileName).isEmpty()) {
-					// Add .html for in line submissions
-					if (INLINE_SUBMISSION.equals(fileName)) {
-						fileName += HTML_EXTENSION;
-						// Else add .docx
-					} else {
-						fileName += DOCX_EXTENSION;
-					}
-				}
+				// Get filename of submission						
+				String fileName = resource.getProperties().getProperty(ResourceProperties.PROP_DISPLAY_NAME);						
 				// If fileName is empty set default
 				if (StringUtils.isEmpty(fileName)) {
 					fileName = "submission_" + item.getUserId() + "_" + item.getSiteId();
 					log.info("Using Default Filename " + fileName);
-				}
+				}				
+				// Add .html for inline submissions
+				ResourceProperties resourceProperties = resource.getProperties();
+				if ("true".equals(resourceProperties.getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))) {
+					fileName += HTML_EXTENSION;
+				}								
 				try {
 					log.info("Submission starting...");
 					// Retrieve submissionId from TCA and set to externalId

--- a/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
+++ b/content-review/impl/turnitin-oc/src/main/java/org/sakaiproject/contentreview/turnitin/oc/ContentReviewServiceTurnitinOC.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.sakaiproject.assignment.api.AssignmentConstants;
@@ -672,11 +673,11 @@ public class ContentReviewServiceTurnitinOC extends BaseContentReviewService {
 					fileName = "submission_" + item.getUserId() + "_" + item.getSiteId();
 					log.info("Using Default Filename " + fileName);
 				}				
-				// Add .html for inline submissions
-				ResourceProperties resourceProperties = resource.getProperties();
-				if ("true".equals(resourceProperties.getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))) {
+				// Add .html for inline submissions				
+				if ("true".equals(resource.getProperties().getProperty(AssignmentConstants.PROP_INLINE_SUBMISSION))
+						&& FilenameUtils.getExtension(fileName).isEmpty()) {
 					fileName += HTML_EXTENSION;
-				}								
+				}							
 				try {
 					log.info("Submission starting...");
 					// Retrieve submissionId from TCA and set to externalId


### PR DESCRIPTION
created constants for file extensions

Using io.FileNameUtils to check extension type
inline submissions missing extension defualt .html
uploaded files missing extension default to .docx

moved fileName creation to inside stage 1 as it is the only place used. 

